### PR TITLE
Variable cacheing fixed by extending types with a `cacheVariable` 

### DIFF
--- a/gosymbol.go
+++ b/gosymbol.go
@@ -633,10 +633,10 @@ func Simplify(expr Expr) Expr {
 	// simplification rule has actually been applied.
 	rulesApplication := func(expr Expr, ruleSlice []transformationRule) (Expr, bool) {
 		atLeastOneapplied := false
-		for _, rule := range ruleSlice {
+		for ix, rule := range ruleSlice {
 			var applied bool
 			expr, applied = rule.apply(expr)
-			//if applied { fmt.Println("Applied rule ", ix) }
+			if applied { fmt.Println("Applied rule ", ix) }
 			atLeastOneapplied = atLeastOneapplied || applied
 		}
 		return expr, atLeastOneapplied
@@ -715,7 +715,8 @@ func patternMatch(pattern, expr Expr, varCache map[VarName]Expr) bool {
 		} else if cacheOk && varOk && Equal(v, eTyped) {
 			return false
 		} else if cacheOk && varOk {
-			return patternMatch(e, expr, varCache)	
+			return false
+			//return patternMatch(e, expr, varCache)	
 		} else if cacheOk {
 			return patternMatch(e, expr, varCache)
 		} else {

--- a/gosymbol.go
+++ b/gosymbol.go
@@ -17,12 +17,16 @@ func Const(val float64) constant {
 	return constant{Value: val}
 }
 
+func CacheVar(name VarName) cacheVariable {
+	return cacheVariable{Name: name}
+}
+
 func Var(name VarName) variable {
 	return variable{Name: name}
 }
 
-func ConstrVar(name VarName, constrFunc func(Expr) bool) constrainedVariable {
-	return constrainedVariable{Name: name, Constraint: constrFunc}
+func ConstrCacheVar(name VarName, constrFunc func(Expr) bool) cacheVariable {
+	return cacheVariable{Name: name, Constraint: constrFunc}
 }
 
 func Neg(arg Expr) mul {
@@ -187,10 +191,6 @@ func (e variable) String() string {
 	return string(e.Name)
 }
 
-func (e constrainedVariable) String() string {
-	return fmt.Sprintf("%v_CONSTRAINED", e.Name)
-}
-
 func (e add) String() string {
 	str := fmt.Sprintf("( %v", e.Operands[0])
 	for ix := 1; ix < len(e.Operands); ix++ {
@@ -268,8 +268,6 @@ func replaceOperand(t Expr, n int, u Expr) Expr {
 		return v
 	case variable:
 		return v
-	case constrainedVariable:
-		return v
 	case add:
 		v.Operands[n-1] = u
 		return v
@@ -325,9 +323,6 @@ func Equal(t, u Expr) bool {
 	case variable:
 		uTyped, ok := u.(variable)
 		return ok && v.Name == uTyped.Name
-	case constrainedVariable:
-		// TODO: how do we check equality of constrain??
-		return false
 	case add:
 		_, ok := u.(add)
 		if !ok {
@@ -435,9 +430,6 @@ func Contains(expr, u Expr) bool {
 	case variable:
 		uTyped, ok := u.(variable)
 		return ok && v.Name == uTyped.Name
-	case constrainedVariable:
-		// TODO: how do we check equality of constrain??
-		return false
 	default:
 		if Equal(v,u) {return true}
 		for ix := 1; ix <= NumberOfOperands(v); ix++ {
@@ -487,8 +479,6 @@ func variableNames(expr Expr, targetSlice *[]string) {
 		return
 	case variable:
 		*targetSlice = append(*targetSlice, string(v.Name))
-	case constrainedVariable:
-		*targetSlice = append(*targetSlice, string(v.Name))
 	default:
 		for ix := 1; ix <= NumberOfOperands(expr); ix++ {
 			op := Operand(expr, ix)
@@ -505,8 +495,6 @@ func NumberOfOperands(expr Expr) int {
 	case constant:
 		return 0
 	case variable:
-		return 0
-	case constrainedVariable:
 		return 0
 	case add:
 		return len(v.Operands)
@@ -542,8 +530,6 @@ func Operand(expr Expr, n int) Expr {
 	case constant:
 		return nil
 	case variable:
-		return nil
-	case constrainedVariable:
 		return nil
 	case add:
 		return v.Operands[n-1]
@@ -583,8 +569,6 @@ func Depth(expr Expr) int {
 	case constant:
 		return 0
 	case variable:
-		return 0
-	case constrainedVariable:
 		return 0
 	default:
 		maxDepth := 0
@@ -651,8 +635,6 @@ func Simplify(expr Expr) Expr {
 		// Fully simplified
 	case variable:
 		// Fully simplified 
-	case constrainedVariable:
-		// Fully simplified 
 	case add:
 		expr, expressionAltered = rulesApplication(expr, sumSimplificationRules)
 	case mul:
@@ -684,7 +666,9 @@ func (rule transformationRule) match(expr Expr) bool {
 	// we execute patternFunction if it exists. 
 	// If no pattern or patternFunction exists we return false 
 	if rule.pattern != nil {
-		varCache := make(map[VarName]Expr)
+		// TODO: Below two lines is ugly, cant you initialise in same row?
+		varCache := variableCache{}
+		varCache.cache = make(map[VarName]Expr)
 		return patternMatch(rule.pattern, expr, varCache)
 	} else if rule.patternFunction != nil {
 		return rule.patternFunction(expr)
@@ -699,7 +683,7 @@ map internally used to keep track of what the variables in pattern
 corresponds to in expr. The function expects that no variable has the 
 same name as a constrained variable.
 */
-func patternMatch(pattern, expr Expr, varCache map[VarName]Expr) bool {
+func patternMatch(pattern, expr Expr, varCache variableCache) bool {
 	switch v := pattern.(type) {
 	case undefined:
 		_, ok := expr.(undefined)
@@ -707,33 +691,29 @@ func patternMatch(pattern, expr Expr, varCache map[VarName]Expr) bool {
 	case constant:
 		exprTyped, ok := expr.(constant)
 		return ok && v.Value == exprTyped.Value 
-	case variable:
-		e, cacheOk := varCache[v.Name]
-		eTyped, varOk := e.(variable)
-		if cacheOk && Equal(e, expr) {
+	case cacheVariable:
+		// If the cached variable as an expression assigned to it we pattern 
+		// match it with `expr`. If it does not and there is no constraint 
+		// on the variable defined in the pattern we cache current expression,
+		// otherwise we just check if the constraint is satisfied and then cache.
+		if !varCache.isUnassigned(v.Name) {
+			cachedExpr := varCache.get(v.Name)
+			return patternMatch(cachedExpr, expr, varCache)
+		} else if v.Constraint == nil {
+			varCache.add(v.Name, expr)	
 			return true
-		} else if cacheOk && varOk && Equal(v, eTyped) {
-			return false
-		} else if cacheOk && varOk {
-			return false
-			//return patternMatch(e, expr, varCache)	
-		} else if cacheOk {
-			return patternMatch(e, expr, varCache)
-		} else {
-			varCache[v.Name] = expr
-			return true
-		}
-	case constrainedVariable:
-		// Does just as above but before assigning an expression
-		// to a variable the constraint function is checked as well
-		if e, ok := varCache[v.Name]; ok {
-			return patternMatch(e, expr, varCache)
 		} else if v.Constraint(expr) {
-			varCache[v.Name] = expr
+			varCache.add(v.Name, expr)
 			return true
-		} else {
+		}
+		return false
+	case variable:
+		// TODO: we want this case to only happen when above case pattern matches against cached stuff
+		exprTyped, ok := expr.(variable)
+		if !ok {
 			return false
 		}
+		return v.Name == exprTyped.Name 
 	case add:
 		_, ok := expr.(add)
 		if !ok {
@@ -773,7 +753,7 @@ func patternMatch(pattern, expr Expr, varCache map[VarName]Expr) bool {
 // Checks if the operands of pattern and expr match.
 // This function does not check if the main operator
 // of pattern and expr match.
-func patternMatchOperands(pattern, expr Expr, varCache map[VarName]Expr) bool {
+func patternMatchOperands(pattern, expr Expr, varCache variableCache) bool {
 	if NumberOfOperands(pattern) != NumberOfOperands(expr) {
 		return false
 	}
@@ -831,32 +811,6 @@ func compare(e1, e2 Expr) bool {
 			return false
 		case variable:
 			return orderRule2(e1Typed, e2Typed)
-		case constrainedVariable:
-			return e1Typed.Name < e2Typed.Name // This is very ugly :(
-		case add:
-			return compare(Add(e1), e2)
-		case mul:
-			return compare(Mul(e1), e2)
-		case pow:
-			return compare(Pow(e1, Const(1)), e2)
-		case exp:
-			return compare(Exp(e1), e2)
-		case log:
-			return compare(Log(e1), e2)
-		case sqrt:
-			return compare(Sqrt(e1), e2)
-		default:
-			errMsg := fmt.Sprintf("ERROR: function is not implemented for type: %v", reflect.TypeOf(e1Typed))
-			panic(errMsg)
-		}
-	case constrainedVariable:
-		switch e2Typed := e2.(type) {
-		case constant:
-			return false
-		case variable:
-			return e1Typed.Name < e2Typed.Name // This is very ugly :(
-		case constrainedVariable:
-			return orderRule2_1(e1Typed, e2Typed)
 		case add:
 			return compare(Add(e1), e2)
 		case mul:
@@ -878,8 +832,6 @@ func compare(e1, e2 Expr) bool {
 		case constant:
 			return false
 		case variable:
-			return compare(e1, Add(e2))
-		case constrainedVariable:
 			return compare(e1, Add(e2))
 		case add:
 			return orderRule3(e1Typed, e2Typed)
@@ -903,8 +855,6 @@ func compare(e1, e2 Expr) bool {
 			return false
 		case variable:
 			return compare(e1, Mul(e2))
-		case constrainedVariable:
-			return compare(e1, Mul(e2))
 		case add: 
 			return compare(e1, Mul(e2))
 		case mul:
@@ -927,8 +877,6 @@ func compare(e1, e2 Expr) bool {
 			return false
 		case variable:
 			return compare(e1, Pow(e2, Const(1)))
-		case constrainedVariable:
-			return compare(e1, Pow(e2, Const(1)))
 		case add: 
 			return compare(e1, Pow(e2, Const(1)))
 		case mul:
@@ -950,8 +898,6 @@ func compare(e1, e2 Expr) bool {
 		case constant:
 			return false
 		case variable:
-			return compare(e1, Exp(e2))
-		case constrainedVariable:
 			return compare(e1, Exp(e2))
 		case add:
 			return compare(Add(e1), e2)
@@ -981,8 +927,6 @@ func compare(e1, e2 Expr) bool {
 			return false
 		case variable:
 			return compare(e1, Exp(e2))
-		case constrainedVariable:
-			return compare(e1, Exp(e2))
 		case add:
 			return compare(Add(e1), e2)
 		case mul:
@@ -1010,8 +954,6 @@ func compare(e1, e2 Expr) bool {
 		case constant:
 			return false
 		case variable:
-			return compare(e1, Exp(e2))
-		case constrainedVariable:
 			return compare(e1, Exp(e2))
 		case add:
 			return compare(Add(e1), e2)
@@ -1043,7 +985,6 @@ func compare(e1, e2 Expr) bool {
 
 func orderRule1(e1, e2 constant) bool {return e1.Value < e2.Value}
 func orderRule2(e1, e2 variable) bool {return e1.Name < e2.Name}
-func orderRule2_1(e1, e2 constrainedVariable) bool {return e1.Name < e2.Name}
 func orderRule3(e1, e2 add) bool {
 	e1NumOp := NumberOfOperands(e1)
 	e2NumOp := NumberOfOperands(e2)
@@ -1169,3 +1110,35 @@ func topOperandSort(expr Expr) Expr {
 }
 
 func TopOperandSort(expr Expr) Expr { return topOperandSort(expr) }
+
+/* Variable Cacheing */
+
+/*
+Addes `expr` to cache as `key`. Note that if `key` is already in vc it will be 
+over-written.
+*/
+func (vc variableCache) add(key VarName, expr Expr) {
+	vc.cache[key] = expr	
+}
+
+// TODO
+func (vc variableCache) remove(key string, expr Expr) {}
+
+/*
+Returns the exression cached as `key`. Note that this method 
+assumes that `key` exists in the underlying map.
+*/
+func (vc variableCache) get(key VarName) Expr {
+	return vc.cache[key]
+}
+
+// TODO
+func (vc variableCache) isCached(expr Expr) bool {
+	return false
+}
+
+func (vc variableCache) isUnassigned(key VarName) bool {
+	_, ok := vc.cache[key]
+	return !ok
+}
+

--- a/gosymbol_test.go
+++ b/gosymbol_test.go
@@ -545,10 +545,6 @@ func TestDepth(t *testing.T) {
 			expectedOutput: 0,
 		},
 		{
-			input: gosymbol.ConstrVar("x", func(expr gosymbol.Expr) bool {return true}),
-			expectedOutput: 0,
-		},
-		{
 			input: gosymbol.Add(gosymbol.Const(0), gosymbol.Var("x"),gosymbol.Const(0), gosymbol.Var("x"),gosymbol.Const(0), gosymbol.Var("x")),
 			expectedOutput: 1,
 		},
@@ -564,24 +560,3 @@ func TestDepth(t *testing.T) {
 	}
 }
 
-func TestTemp(t *testing.T) {
-	tests := []struct{
-		input gosymbol.Expr
-		expectedOutput gosymbol.Expr
-	}{ 
-		{	// x * (1/x) = 1
-			input: gosymbol.Mul(gosymbol.Var("x"), gosymbol.Div(gosymbol.Const(1), gosymbol.Var("x"))),
-			expectedOutput: gosymbol.Const(1),
-		},
-	}
-
-	for ix, test := range tests {
-		result := gosymbol.Simplify(test.input)
-		correctnesCheck(t, result, test.expectedOutput, ix+1)
-	}
-
-	//e := gosymbol.Mul(gosymbol.Pow(gosymbol.Var("x"), gosymbol.Const(3)), gosymbol.Var("x"))
-	e1 := gosymbol.Mul(gosymbol.Var("x"), gosymbol.Div(gosymbol.Const(1), gosymbol.Var("x")))
-	fmt.Println("unsorted: ", e1)
-	fmt.Println("sorted: ", gosymbol.TopOperandSort(gosymbol.Add(gosymbol.Var("m"), gosymbol.Const(-1), gosymbol.Const(9), gosymbol.Neg(gosymbol.Var("m")))))
-}

--- a/gosymbol_test.go
+++ b/gosymbol_test.go
@@ -509,11 +509,18 @@ func TestSimplify(t *testing.T) {
 			input: gosymbol.Mul(gosymbol.Pow(gosymbol.Var("x"), gosymbol.Var("n")), gosymbol.Pow(gosymbol.Var("x"), gosymbol.Var("m"))),
 			expectedOutput: gosymbol.Pow(gosymbol.Var("x"), gosymbol.Add(gosymbol.Var("m"), gosymbol.Var("n"))),
 		},
+		{
+			input: gosymbol.Mul(gosymbol.Pow(gosymbol.Var("y"), gosymbol.Var("j")), gosymbol.Pow(gosymbol.Var("y"), gosymbol.Var("i"))),
+			expectedOutput: gosymbol.Pow(gosymbol.Var("y"), gosymbol.Add(gosymbol.Var("i"), gosymbol.Var("j"))),
+		},
+		{
+			input: gosymbol.Mul(gosymbol.Pow(gosymbol.Var("y"), gosymbol.Var("i")), gosymbol.Pow(gosymbol.Var("y"), gosymbol.Var("i"))),
+			expectedOutput: gosymbol.Pow(gosymbol.Var("y"), gosymbol.Mul(gosymbol.Const(2), gosymbol.Var("i"))),
+		},
 	}
 
 	for ix, test := range tests {
 		t.Run(fmt.Sprint(ix+1), func(t *testing.T) {
-			//fmt.Println("Simplifying: ", test.input)
 			result := gosymbol.Simplify(test.input)
 			correctnesCheck(t, result, test.expectedOutput, ix+1)
 		})

--- a/simplification_rules.go
+++ b/simplification_rules.go
@@ -22,7 +22,7 @@ func negOrZeroConstant(expr Expr) bool {
 
 var sumSimplificationRules []transformationRule = []transformationRule{
 	{ // Addition with only one operand simplify to the operand
-		pattern: Add(Var("x")),
+		pattern: Add(CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			return Operand(expr, 1)
 		},
@@ -36,7 +36,7 @@ var sumSimplificationRules []transformationRule = []transformationRule{
 	{ // x - x = 0. Due to the ordering the negative term will always be first.
 	  // Note that this will not work for constants since Const(-c) is a float
 	  // while -x = -1*x. 
-		pattern: Add(Neg(Var("x")), Var("x")),
+		pattern: Add(Neg(CacheVar("x")), CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			return Const(0)
 		},
@@ -104,7 +104,7 @@ var productSimplificationRules []transformationRule = []transformationRule{
 		transform: func(expr Expr) Expr {return Const(0)},
 	},
 	{ // Multiplication with only one operand simplify to the operand
-		pattern: Mul(Var("x")),
+		pattern: Mul(CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			return Operand(expr, 1)
 		},
@@ -138,14 +138,14 @@ var productSimplificationRules []transformationRule = []transformationRule{
 		},
 	},
 	{ // x*x = x^2
-		pattern: Mul(Var("x"), Var("x")),
+		pattern: Mul(CacheVar("x"), CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			base := Operand(expr, 1)
 			return Pow(base, Const(2))
 		},
 	},
 	{ // x*x^n = x^(n+1) this applies to positive n due to the ordering of an expression
-		pattern: Mul(Var("x"), Pow(Var("x"), Var("y"))),
+		pattern: Mul(CacheVar("x"), Pow(CacheVar("x"), CacheVar("y"))),
 		transform: func(expr Expr) Expr {
 			newBase := Operand(expr, 1)
 			oldExponent := Operand(Operand(expr, 2), 2)
@@ -154,7 +154,7 @@ var productSimplificationRules []transformationRule = []transformationRule{
 		},
 	},
 	{ // x^n * x = x^(n+1) this applies to negative n due to the ordering of an expression
-		pattern: Mul(Pow(Var("x"), Var("y")), Var("x")),
+		pattern: Mul(Pow(CacheVar("x"), CacheVar("y")), CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			newBase := Operand(expr, 2)
 			oldExponent := Operand(Operand(expr, 1), 2)
@@ -163,7 +163,7 @@ var productSimplificationRules []transformationRule = []transformationRule{
 		},
 	},
 	{ // x^(n) * x^(m) = x^(n+m)
-		pattern: Mul(Pow(Var("x"), Var("n")), Pow(Var("x"), Var("m"))),
+		pattern: Mul(Pow(CacheVar("x"), CacheVar("n")), Pow(CacheVar("x"), CacheVar("m"))),
 		transform: func(expr Expr) Expr {
 			base := Operand(Operand(expr, 1), 1)
 			exponent1 := Operand(Operand(expr, 1), 2)
@@ -175,25 +175,25 @@ var productSimplificationRules []transformationRule = []transformationRule{
 
 var powerSimplificationRules []transformationRule = []transformationRule{
 	{ // 0^x = 0 for x in R_+
-		pattern: Pow(Const(0), ConstrVar("x", positiveConstant)),
+		pattern: Pow(Const(0), ConstrCacheVar("x", positiveConstant)),
 		transform: func(expr Expr) Expr {
 			return Const(0) 
 		},
 	},
 	{ // 0^x = Undefined for x <= 0
-		pattern: Pow(Const(0), ConstrVar("x", negOrZeroConstant)),
+		pattern: Pow(Const(0), ConstrCacheVar("x", negOrZeroConstant)),
 		transform: func(expr Expr) Expr {
 			return Undefined()
 		},
 	},
 	{ // 1^x = 1
-		pattern: Pow(Const(1), Var("x")),
+		pattern: Pow(Const(1), CacheVar("x")),
 		transform: func(expr Expr) Expr {
 			return Const(1)
 		},
 	},
 	{ // x^0 = 1
-		pattern: Pow(Var("x"), Const(0)),
+		pattern: Pow(CacheVar("x"), Const(0)),
 		transform: func(expr Expr) Expr {
 			return Const(1)
 		},
@@ -218,7 +218,7 @@ var powerSimplificationRules []transformationRule = []transformationRule{
 		},
 	},
 	{ // (x^y)^z = x^(y*z)
-		pattern: Pow(Pow(Var("x"), Var("y")), Var("z")),
+		pattern: Pow(Pow(CacheVar("x"), CacheVar("y")), CacheVar("z")),
 		transform: func(expr Expr) Expr {	
 			x := Operand( Operand(expr, 1), 1)
 			y := Operand( Operand(expr, 1), 2)

--- a/types.go
+++ b/types.go
@@ -11,27 +11,30 @@ type Expr interface {
 	D(VarName) Expr
 }
 
-// A constrainedVariable is just like the data type
-// variable but it has a constraint function. When trying
-// to replace the variable with another expression, this
-// function is run, testing whether the new expression satisfy
-// the constrain, if yes it returns true and false otherwise.
-// Note that you yourself need to define this function to fit your
-// needs. TODO: replace this with some sort of logic DSL :)
-type constrainedVariable struct {
+/**
+Type used for storing expressions to enable advanced pattern matching.
+Without constrain this is a different type from `variable` to remove problems of 
+cacheing a variable as itself, and thus creating infinite recursion fuck ups.
+
+If the Constraint field is set it ought to be checked before caching. This featrues make 
+it possible to define patterns like 0^n = undefined if n < 0.
+*/
+type cacheVariable struct {
 	Expr
 	Name VarName
 	Constraint func(expr Expr) bool
 }
 
-// Used to define transformations from an expression
-// into another. The transformation can happen in two ways:
-// TODO: continue documentation and mention that a variable with
-// the same name as an constrained variable is considered to the same
-// variable by mathPattern.
-//
-//This structure is, for example, used in the simplifation
-// of expressions. 
+/** 
+Used to define transformations from an expression
+into another. The transformation can happen in two ways:
+TODO: continue documentation and mention that a variable with
+the same name as an constrained variable is considered to the same
+variable by mathPattern.
+
+This structure is, for example, used in the simplifation
+of expressions. 
+*/
 type transformationRule struct {
 	// One of pattern and patternFunction must be defined.
 	// pattern is prioritised, i.e. if pattern is matched 
@@ -42,6 +45,10 @@ type transformationRule struct {
 
 	// The mapping from pattern to whatever you define
 	transform func(Expr) Expr 
+}
+
+type variableCache struct {
+	cache map[VarName]Expr
 }
 
 /* Basic operators */


### PR DESCRIPTION
Variable cacheing fixed by extending types with a `cacheVariable` used to separate the pattern domain and the expression domain in the `patternMatch` function. It came at the cost of removing the `constrainedVariable` type and the functionality that came with it. But tbh I saw more confusion about that type than I saw nice features :)